### PR TITLE
Fix enums - allow string as value, require `id`

### DIFF
--- a/ksy_schema.json
+++ b/ksy_schema.json
@@ -337,9 +337,8 @@
       }
     },
     "EnumValueSpec": {
-      "$ref": "#/definitions/Identifier",
       "anyOf": [
-        { "type": "string" },
+        { "$ref": "#/definitions/Identifier" },
         {
           "type": "object",
           "additionalProperties": false,

--- a/ksy_schema.json
+++ b/ksy_schema.json
@@ -339,6 +339,7 @@
     "EnumValueSpec": {
       "$ref": "#/definitions/Identifier",
       "anyOf": [
+        { "type": "string" },
         {
           "type": "object",
           "additionalProperties": false,
@@ -348,6 +349,9 @@
             "doc-ref": { "type": "string" },
             "-orig-id": { "type": "string" }
           },
+          "required": [
+            "id"
+          ],
           "patternProperties": {
             "^-.*$": { "$ref": "#/definitions/StringOrInteger" }
           }


### PR DESCRIPTION
The schema allows specifying enum members only in "verbose" format (https://github.com/kaitai-io/kaitai_struct/issues/70#issuecomment-269937635), it doesn't allow the "brief" one.

On top of that, when the verbose format is chosen, `id` must be specified (otherwise KSC will throw an error), which isn't enforced by the schema.