### PR TITLE
Specify default values where applicable

### DIFF
--- a/ksy_schema.json
+++ b/ksy_schema.json
@@ -275,7 +275,8 @@
       "if": {
         "properties": {
           "type": { "const": "strz" }
-        }
+        },
+        "required": ["type"]
       },
       "then": {
         "not": { "required": [ "terminator" ] }

--- a/ksy_schema.json
+++ b/ksy_schema.json
@@ -243,19 +243,23 @@
         },
         "terminator": {
           "type": "integer",
-          "description": "string reading will stop when it encounters this value default is 0"
+          "description": "string reading will stop when it encounters this value\n\ndefault is 0",
+          "default": 0
         },
         "consume": {
           "type": "boolean",
-          "description": "specify if terminator byte should be \"consumed\" when reading\n\nif true: the stream pointer will point to the byte after the terminator byte\n\nif false: the stream pointer will point to the terminator byte itself\n\ndefault is true"
+          "description": "specify if terminator byte should be \"consumed\" when reading\n\nif true: the stream pointer will point to the byte after the terminator byte\n\nif false: the stream pointer will point to the terminator byte itself\n\ndefault is true",
+          "default": true
         },
         "include": {
           "type": "boolean",
-          "description": "specifies if terminator byte should be considered part of the string read and thus be appended to it\n\ndefault is false"
+          "description": "specifies if terminator byte should be considered part of the string read and thus be appended to it\n\ndefault is false",
+          "default": false
         },
         "eos-error": {
           "type": "boolean",
-          "description": "allows the compiler to ignore the lack of a terminator if eos-error is disabled, string reading will stop at either:\n\n(1.) terminator being encountered\n\n(2.) end of stream is reached\n\ndefault is TRUE"
+          "description": "allows the compiler to ignore the lack of a terminator if eos-error is disabled, string reading will stop at either:\n\n(1.) terminator being encountered\n\n(2.) end of stream is reached\n\ndefault is TRUE",
+          "default": true
         },
         "pos": {
           "description": "specifies position at which the value should be parsed",

--- a/ksy_schema.json
+++ b/ksy_schema.json
@@ -243,8 +243,7 @@
         },
         "terminator": {
           "type": "integer",
-          "description": "string reading will stop when it encounters this value\n\ndefault is 0",
-          "default": 0
+          "description": "string or byte array reading will stop when it encounters this byte\n\ncannot be used with \"type: strz\" (which already implies \"terminator: 0\" - null-terminated string)"
         },
         "consume": {
           "type": "boolean",
@@ -272,6 +271,14 @@
         "value": {
           "description": "overrides any reading & parsing. Instead, just calculates function specified in value and returns the result as this instance. Has many purposes"
         }
+      },
+      "if": {
+        "properties": {
+          "type": { "const": "strz" }
+        }
+      },
+      "then": {
+        "not": { "required": [ "terminator" ] }
       }
     },
     "Attributes": {


### PR DESCRIPTION
IMHO it's better to have default values specified in `default` keyword, as it's [supported by JSON Schema](https://json-schema.org/understanding-json-schema/reference/generic.html?highlight=default), because it's machine readable, not just some side note in the description. I've left them in descriptions for information purposes, it might be handful for the user to see it too.