### PR TITLE
Fix dash-prefixed properties

### DIFF
--- a/ksy_schema.json
+++ b/ksy_schema.json
@@ -36,7 +36,7 @@
     }
   },
   "patternProperties": {
-    "^-.*$": { "$ref": "#/definitions/StringOrInteger" }
+    "^-.*$": true
   },
   "definitions": {
     "MetaSpec": {
@@ -280,7 +280,7 @@
         }
       },
       "patternProperties": {
-        "^-.*$": { "$ref": "#/definitions/StringOrInteger" }
+        "^-.*$": true
       }
     },
     "Attributes": {
@@ -313,7 +313,7 @@
         "doc-ref": { "type": "string" }
       },
       "patternProperties": {
-        "^-.*$": { "$ref": "#/definitions/StringOrInteger" }
+        "^-.*$": true
       }
     },
     "TypesSpec": {
@@ -362,7 +362,7 @@
             "-orig-id": { "type": "string" }
           },
           "patternProperties": {
-            "^-.*$": { "$ref": "#/definitions/StringOrInteger" }
+            "^-.*$": true
           }
         }
       ]

--- a/ksy_schema.json
+++ b/ksy_schema.json
@@ -278,6 +278,9 @@
         "value": {
           "description": "overrides any reading & parsing. Instead, just calculates function specified in value and returns the result as this instance. Has many purposes"
         }
+      },
+      "patternProperties": {
+        "^-.*$": { "$ref": "#/definitions/StringOrInteger" }
       }
     },
     "Attributes": {

--- a/ksy_schema.json
+++ b/ksy_schema.json
@@ -122,6 +122,9 @@
             }
           ]
         }
+      },
+      "patternProperties": {
+        "^-.*$": true
       }
     },
     "Attribute": {
@@ -333,6 +336,9 @@
         "type": { "type": "string" },
         "doc": { "type": "string" },
         "doc-ref": { "type": "string" }
+      },
+      "patternProperties": {
+        "^-.*$": true
       },
       "required": ["id"]
     },


### PR DESCRIPTION
* Removes the restriction on the type of dash-prefixed properties - they are meant to be freely usable by users and tools.
* Adds support for dash-prefixed properties on fields and instances, which was previously not allowed by the spec (but is accepted by the compiler and widely used in kaitai_struct_formats).