### PR TITLE
Allow license field be an array

### DIFF
--- a/ksy_schema.json
+++ b/ksy_schema.json
@@ -216,7 +216,16 @@
             }
           }
         },
-        "license": { "type": "string" },
+        "license": {
+          "description": "a string or an array of strings which matches one of the identifiers within the [SPDX license list](https://spdx.org/licenses/)",
+          "anyOf": [
+            { "type": "string" },
+            {
+              "type": "array",
+              "items": { "type": "string" }
+            }
+          ]
+        },
         "ks-version": {
           "anyOf": [
             { "type": "string" },


### PR DESCRIPTION
Nowadays, many projects have a dual licensing scheme, for example MIT/Apache-2.0. As I see, compiler actually don't check format of `license` field (checked in stable and dev WebIDE).