### PR TITLE
Fix `type.cases` part of #kaitai_struct/773

### DIFF
--- a/ksy_schema.json
+++ b/ksy_schema.json
@@ -270,6 +270,59 @@
         "^-.*$": true
       }
     },
+    "TypeRef": {
+      "anyOf": [
+        {
+          "description": "name of or path to existing type name\n\nif name is single path element, then type resolved in such order:\n- from subtypes of current type\n- current type (so, recursive types is possible)\n- parent type\n\none can reference a nested user-defined type by specifying a relative path to it from the current type, with a double colon as a path delimiter (e.g. `foo::bar::my_type`)",
+          "type": "string",
+          "pattern": "^([a-z][a-z0-9_]*::)*[a-z][a-z0-9_]*$"
+        },
+        { "type": "boolean" },
+        { "type": "null" },
+        {
+          "enum": [
+            "u1",
+
+            "u2",
+            "u2le",
+            "u2be",
+
+            "u4",
+            "u4le",
+            "u4be",
+
+            "u8",
+            "u8le",
+            "u8be",
+
+            "s1",
+
+            "s2",
+            "s2le",
+            "s2be",
+
+            "s4",
+            "s4le",
+            "s4be",
+
+            "s8",
+            "s8le",
+            "s8be",
+
+            "f4",
+            "f4be",
+            "f4le",
+
+            "f8",
+            "f8be",
+            "f8le",
+
+            "str",
+            "strz"
+          ]
+        }
+      ]
+    },
     "Attribute": {
       "additionalProperties": false,
       "type": "object",
@@ -301,9 +354,7 @@
         "type": {
           "description": "defines data type for an attribute\n\nthe type can also be user-defined in the `types` key\n\none can reference a nested user-defined type by specifying a relative path to it from the current type, with a double colon as a path delimiter (e.g. `foo::bar::my_type`)",
           "anyOf": [
-            {
-              "type": "string"
-            },
+            { "$ref": "#/definitions/TypeRef" },
             {
               "type": "object",
               "additionalProperties": false,
@@ -313,46 +364,13 @@
                   "type": "object",
                   "additionalProperties": false,
                   "patternProperties": {
-                    "^.*$": { "$ref": "#/definitions/AnyScalar" }
+                    "^.*$": { "$ref": "#/definitions/TypeRef" }
                   }
                 }
               },
               "required": [
                 "switch-on",
                 "cases"
-              ]
-            },
-            {
-              "type": "string",
-              "enum": [
-                "u1",
-                "u2",
-                "u2le",
-                "u2be",
-                "u4",
-                "u4le",
-                "u4be",
-                "u8",
-                "u8le",
-                "u8be",
-                "s1",
-                "s2",
-                "s2le",
-                "s2be",
-                "s4",
-                "s4le",
-                "s4be",
-                "s8",
-                "s8le",
-                "s8be",
-                "f4",
-                "f4be",
-                "f4le",
-                "f8",
-                "f8be",
-                "f8le",
-                "str",
-                "strz"
               ]
             }
           ]

--- a/ksy_schema.json
+++ b/ksy_schema.json
@@ -275,7 +275,7 @@
         {
           "description": "name of or path to existing type name\n\nif name is single path element, then type resolved in such order:\n- from subtypes of current type\n- current type (so, recursive types is possible)\n- parent type\n\none can reference a nested user-defined type by specifying a relative path to it from the current type, with a double colon as a path delimiter (e.g. `foo::bar::my_type`)",
           "type": "string",
-          "pattern": "^([a-z][a-z0-9_]*::)*[a-z][a-z0-9_]*$"
+          "pattern": "^([a-z][a-z0-9_]*::)*[a-z][a-z0-9_]*(\\(.+\\))?$"
         },
         { "type": "boolean" },
         { "type": "null" },


### PR DESCRIPTION
Part of https://github.com/kaitai-io/kaitai_struct/issues/773.

@dgelessus, you say:

> This is clearly incorrect here - it allows some values that are definitely not valid (numbers) and disallows some valid values (nested `switch-on/cases`).

Do you mean that the following ksy should be allowed?
```yaml
seq:
  - type:
      switch-on: ...
      cases:
        some:
          switch-on: ...
```
That syntax currently not allowed by compiler:
> Parse error: undefined
> Call stack: undefined io.kaitai.struct.format.YAMLParseException: /seq/0/cases/some: expected string, got Map(switch-on -> 3, cases -> u1) (class scala.collection.immutable.MapLike$$anon$2)