### PR TITLE
Add `valid` to schema

### DIFF
--- a/ksy_schema.json
+++ b/ksy_schema.json
@@ -732,6 +732,19 @@
               "$ref": "#/definitions/AnyScalar"
             }
           }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "in-enum"
+          ],
+          "properties": {
+            "in-enum": {
+              "description": "consider only values defined in the enum as valid\n\ncan only be used on enum attributes (i.e. those that use the `enum` key)\n\nif the actual integer value does not correspond to any defined member of the enum, a `ValidationNotInEnumError` exception will be thrown",
+              "const": true
+            }
+          }
         }
       ]
     },

--- a/ksy_schema.json
+++ b/ksy_schema.json
@@ -410,7 +410,7 @@
           ]
         },
         "valid": {
-          "description": "expected value that the parser should encounter at this point (or throw an error). Unlike `contents`, this is the value *after* parsing.",
+          "description": "condition that the attribute value is expected to satisfy.",
           "$ref": "#/definitions/ValidationSpec"
         },
         "type": {
@@ -668,23 +668,30 @@
     "ValidationSpec": {
       "anyOf": [
         {
-          "type": "integer"
-        },
-        {
-          "type": "string"
+          "description": "Exact value. Shorthand for `eq: value`",
+          "$ref": "#/definitions/AnyScalar"
         },
         {
           "type": "object",
           "additionalProperties": false,
           "properties": {
-            "eq": {}
+            "eq": {
+              "description": "Exact value this attribute is expected to have",
+              "$ref": "#/definitions/AnyScalar"
+            }
           }
         },
         {
           "type": "object",
           "additionalProperties": false,
           "properties": {
-            "expr": {}
+            "expr": {
+              "type": "string",
+              "description": "An expression that evaluates to 'true' for the attribute to be considered valid. Refer to the value with `_`",
+              "examples": [
+                "_ % 2 == 0"
+              ]
+            }
           }
         },
         {
@@ -692,7 +699,11 @@
           "additionalProperties": false,
           "properties": {
             "any-of": {
-              "type": "array"
+              "description": "Exact value this attribute is expected to have",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/AnyScalar"
+              }
             }
           }
         },

--- a/ksy_schema.json
+++ b/ksy_schema.json
@@ -411,7 +411,7 @@
         },
         "valid": {
           "description": "expected value that the parser should encounter at this point (or throw an error). Unlike `contents`, this is the value *after* parsing.",
-          "$ref": "#/definitions/ValidationSPec"
+          "$ref": "#/definitions/ValidationSpec"
         },
         "type": {
           "description": "defines data type for an attribute\n\nthe type can also be user-defined in the `types` key\n\none can reference a nested user-defined type by specifying a relative path to it from the current type, with a double colon as a path delimiter (e.g. `foo::bar::my_type`)",

--- a/ksy_schema.json
+++ b/ksy_schema.json
@@ -548,6 +548,22 @@
               }
             ]
           }
+        },
+        {
+          "if": {
+            "properties": {
+              "valid": {
+                "type": "object",
+                "required": [
+                  "in-enum"
+                ]
+              }
+            },
+            "required": ["valid"]
+          },
+          "then": {
+            "required": ["enum"]
+          }
         }
       ]
     },

--- a/ksy_schema.json
+++ b/ksy_schema.json
@@ -410,7 +410,7 @@
           ]
         },
         "valid": {
-          "description": "condition that the attribute value is expected to satisfy.",
+          "description": "validation constraints that the actual value of the attribute must satisfy, otherwise a subclass of `ValidationFailedError` will be raised",
           "$ref": "#/definitions/ValidationSpec"
         },
         "type": {
@@ -668,7 +668,7 @@
     "ValidationSpec": {
       "anyOf": [
         {
-          "description": "Exact value. Shorthand for `eq: value`",
+          "description": "expression that specifies the only valid value for this attribute\n\nshorthand for `eq: value`\n\nif the actual value does not satisfy this constraint, a `ValidationNotEqualError` exception will be thrown",
           "$ref": "#/definitions/AnyScalar"
         },
         {
@@ -676,7 +676,7 @@
           "additionalProperties": false,
           "properties": {
             "eq": {
-              "description": "Exact value this attribute is expected to have",
+              "description": "expression that specifies the only valid value for this attribute\n\nmore explicit, long form of `valid: value`\n\nif the actual value does not satisfy this constraint, a `ValidationNotEqualError` exception will be thrown",
               "$ref": "#/definitions/AnyScalar"
             }
           }
@@ -687,7 +687,7 @@
           "properties": {
             "expr": {
               "type": "string",
-              "description": "An expression that evaluates to 'true' for the attribute to be considered valid. Refer to the value with `_`",
+              "description": "boolean expression that must evaluate to `true` for the attribute value to be considered valid\n\nactual value can be referenced via a special built-in local variable `_`\n\nfor better declarativeness, it should only be used to enforce validation constraints that cannot be captured by any of the other dedicated `valid` subkeys (in other words, other subkeys should be preferred: for example, prefer `max: 5` to `expr: _ <= 5`)\n\nif the actual value does not satisfy this constraint, a `ValidationExprError` exception will be thrown",
               "examples": [
                 "_ % 2 == 0"
               ]
@@ -699,7 +699,7 @@
           "additionalProperties": false,
           "properties": {
             "any-of": {
-              "description": "Exact value this attribute is expected to have",
+              "description": "list of expressions that specify a set of valid values for this attribute (the actual value must be equal to **any of** the values in the list)\n\nif the actual value does not satisfy this constraint, a `ValidationNotAnyOfError` exception will be thrown",
               "type": "array",
               "items": {
                 "$ref": "#/definitions/AnyScalar"
@@ -724,10 +724,12 @@
           ],
           "properties": {
             "min": {
-              "description": "minimum value (inclusive)"
+              "description": "expression that specifies the **minimum** valid value for this attribute\n\nactual value must be greater than or equal to this value (i.e. `min: value` is functionally equivalent to `expr: _ >= value`)\n\nif the actual value does not satisfy this constraint, a `ValidationLessThanError` exception will be thrown\n\ncan be combined with the `max` key to specify a range",
+              "$ref": "#/definitions/AnyScalar"
             },
             "max": {
-              "description": "maximum value (inclusive)"
+              "description": "expression that specifies the **maximum** valid value for this attribute\n\nactual value must be less than or equal to this value (i.e. `max: value` is functionally equivalent to `expr: _ <= value`)\n\nif the actual value does not satisfy this constraint, a `ValidationGreaterThanError` exception will be thrown\n\ncan be combined with the `min` key to specify a range",
+              "$ref": "#/definitions/AnyScalar"
             }
           }
         }

--- a/ksy_schema.json
+++ b/ksy_schema.json
@@ -409,6 +409,10 @@
             }
           ]
         },
+        "valid": {
+          "description": "expected value that the parser should encounter at this point (or throw an error). Unlike `contents`, this is the value *after* parsing.",
+          "$ref": "#/definitions/ValidationSPec"
+        },
         "type": {
           "description": "defines data type for an attribute\n\nthe type can also be user-defined in the `types` key\n\none can reference a nested user-defined type by specifying a relative path to it from the current type, with a double colon as a path delimiter (e.g. `foo::bar::my_type`)",
           "anyOf": [
@@ -657,6 +661,63 @@
           ],
           "patternProperties": {
             "^-.*$": true
+          }
+        }
+      ]
+    },
+    "ValidationSpec": {
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "string"
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "eq": {}
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "expr": {}
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "any-of": {
+              "type": "array"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "anyOf": [
+            {
+              "required": [
+                "min"
+              ]
+            },
+            {
+              "required": [
+                "max"
+              ]
+            }
+          ],
+          "properties": {
+            "min": {
+              "description": "minimum value (inclusive)"
+            },
+            "max": {
+              "description": "maximum value (inclusive)"
+            }
           }
         }
       ]


### PR DESCRIPTION
This was previously undocumented per https://github.com/kaitai-io/kaitai_struct/issues/944

Here's my attempt to document the admissible structure based on the current implementation and documentation at:

https://github.com/kaitai-io/kaitai_struct_compiler/blob/751f059f4a34dddcf7d8f75bd8f89c3ee07f53fc/shared/src/main/scala/io/kaitai/struct/format/ValidationSpec.scala

https://github.com/kaitai-io/kaitai_struct_compiler/blob/751f059f4a34dddcf7d8f75bd8f89c3ee07f53fc/shared/src/main/scala/io/kaitai/struct/languages/components/ValidateOps.scala

https://github.com/kaitai-io/kaitai_struct_doc/blob/c87ae4cb447abfb043bcbade1c8d601037469142/user_guide.adoc#valid-values