### PR TITLE
Validate character encoding

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,46 @@
+name: Check
+
+on:
+  push:
+    branches:
+      - master
+  pull_request: {}
+
+jobs:
+  check-encodings:
+    name: Check that the encoding list is up-to-date with KSC
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out ksy_schema
+        uses: actions/checkout@v4
+        with:
+          path: ksy_schema
+      - name: Get list of encodings from ksy_schema
+        working-directory: ksy_schema
+        run: |
+          jq '.definitions.CharacterEncoding.enum' ksy_schema.json > encodings.json
+
+      - name: Check out compiler
+        uses: actions/checkout@v4
+        with:
+          repository: kaitai-io/kaitai_struct_compiler
+          path: compiler
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+      - uses: sbt/setup-sbt@v1
+      - name: Get list of canonical encodings from KSC
+        working-directory: compiler
+        # Written to work with https://github.com/kaitai-io/kaitai_struct_compiler/blob/56582ef65ca869ca43a1691a496bf4989f938675/shared/src/main/scala/io/kaitai/struct/EncodingList.scala
+        run: |
+          echo 'java.nio.file.Files.write(java.nio.file.Paths.get("encodings.min.json"), io.kaitai.struct.JSON.stringify(io.kaitai.struct.EncodingList.canonicalToAliasEntries.map(_._1)).getBytes(java.nio.charset.StandardCharsets.UTF_8))' \
+            | sbt compilerJVM/console
+          jq . encodings.min.json > encodings.json
+          rm -f encodings.min.json
+
+      - name: Compare encoding lists in ksy_schema and KSC
+        run: |
+          git diff --no-index --exit-code -- ksy_schema/encodings.json compiler/encodings.json

--- a/ksy_schema.json
+++ b/ksy_schema.json
@@ -694,6 +694,8 @@
       ]
     },
     "CharacterEncoding": {
+      "description": "canonical names of character encodings supported by Kaitai Struct\n\nin addition to these canonical names, the compiler (since version 0.11) also recognizes their popular aliases, but issues a warning for them",
+      "$comment": "the `enum` list must be kept in sync with https://github.com/kaitai-io/kaitai_struct_compiler/blob/master/shared/src/main/scala/io/kaitai/struct/EncodingList.scala",
       "enum": [
         "ASCII",
         "UTF-8",

--- a/ksy_schema.json
+++ b/ksy_schema.json
@@ -293,7 +293,7 @@
         },
         "encoding": {
           "$ref": "#/definitions/CharacterEncoding",
-          "description": "default character encoding for string fields (of type `str` or `strz`) in the current type and its subtypes\n\nshould be one of the canonical encodings from [this list](https://github.com/kaitai-io/kaitai_struct_compiler/blob/0fd43b3c2186f9f87e95efcedfc6e723d82ee274/shared/src/main/scala/io/kaitai/struct/EncodingList.scala), otherwise the compiler will issue a warning (since version 0.11)"
+          "description": "default character encoding for string fields (of type `str` or `strz`) in the current type and its subtypes"
         },
         "endian": {
           "anyOf": [

--- a/ksy_schema.json
+++ b/ksy_schema.json
@@ -292,7 +292,7 @@
           ]
         },
         "encoding": {
-          "type": "string",
+          "$ref": "#/definitions/CharacterEncoding",
           "description": "default character encoding for string fields (of type `str` or `strz`) in the current type and its subtypes\n\nshould be one of the canonical encodings from [this list](https://github.com/kaitai-io/kaitai_struct_compiler/blob/0fd43b3c2186f9f87e95efcedfc6e723d82ee274/shared/src/main/scala/io/kaitai/struct/EncodingList.scala), otherwise the compiler will issue a warning (since version 0.11)"
         },
         "endian": {
@@ -479,7 +479,7 @@
           "pattern": "^([a-z][a-z0-9_]*::)*[a-z][a-z0-9_]*$"
         },
         "encoding": {
-          "type": "string"
+          "$ref": "#/definitions/CharacterEncoding"
         },
         "pad-right": {
           "type": "integer",
@@ -691,6 +691,42 @@
         { "type": "integer" },
         { "type": "boolean" },
         { "type": "null" }
+      ]
+    },
+    "CharacterEncoding": {
+      "enum": [
+        "ASCII",
+        "UTF-8",
+        "UTF-16LE",
+        "UTF-16BE",
+        "UTF-32LE",
+        "UTF-32BE",
+        "ISO-8859-1",
+        "ISO-8859-2",
+        "ISO-8859-3",
+        "ISO-8859-4",
+        "ISO-8859-5",
+        "ISO-8859-6",
+        "ISO-8859-7",
+        "ISO-8859-8",
+        "ISO-8859-9",
+        "ISO-8859-10",
+        "ISO-8859-11",
+        "ISO-8859-13",
+        "ISO-8859-14",
+        "ISO-8859-15",
+        "ISO-8859-16",
+        "windows-1250",
+        "windows-1251",
+        "windows-1252",
+        "windows-1253",
+        "windows-1254",
+        "windows-1255",
+        "windows-1256",
+        "windows-1257",
+        "windows-1258",
+        "IBM437",
+        "IBM866"
       ]
     }
   }


### PR DESCRIPTION
Where the schema expects a declared character encoding, validate that it is one of the character encodings recognized by the compiler. When using a smart editor, this makes it easier to author a `.ksy` file.

![image](https://github.com/kaitai-io/ksy_schema/assets/119948/6c0422b4-32d4-470e-bfbb-f2d2527921c7)

I took this list from the recognized encoding list in [Kaitai Struct compiler](https://github.com/kaitai-io/kaitai_struct_compiler/blob/0fd43b3c2186f9f87e95efcedfc6e723d82ee274/shared/src/main/scala/io/kaitai/struct/EncodingList.scala).